### PR TITLE
Fixed issue when attaching / syncing multiple records with attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ public static function boot()
 {
     parent::boot();
 
-    static::pivotAttaching(function ($model, $relationName, $pivotIds) {
+    static::pivotAttaching(function ($model, $relationName, $pivotIds, $pivotIdsAttributes) {
         //
     });
     
-    static::pivotAttached(function ($model, $relationName, $pivotIds) {
+    static::pivotAttached(function ($model, $relationName, $pivotIds, $pivotIdsAttributes) {
         //
     });
     
@@ -72,11 +72,11 @@ public static function boot()
         //
     });
     
-    static::pivotUpdating(function ($model, $relationName, $pivotIds) {
+    static::pivotUpdating(function ($model, $relationName, $pivotIds, $pivotIdsAttributes) {
         //
     });
     
-    static::pivotUpdated(function ($model, $relationName, $pivotIds) {
+    static::pivotUpdated(function ($model, $relationName, $pivotIds, $pivotIdsAttributes) {
         //
     });
     
@@ -99,7 +99,7 @@ You can also see those events here :
 Four BelongsToMany methods dispatches events from this package : 
 
 **attach()** -> dispatches only **one** pivotAttaching and pivotAttached event. 
-Even when more rows are added only **one** event is dispatched but in that case you can see all changed row ids in $pivotIds variable.
+Even when more rows are added only **one** event is dispatched but in that case you can see all changed row ids in $pivotIds variable, and the changed row ids related attributes in $pivotIdsAttributes variable.
 
 **detach()** -> dispatches **one** pivotDetaching and pivotDetached event.
 Even when more rows are deleted only **one** event is dispatched but in that case you can see all changed row ids in $pivotIds variable.
@@ -128,11 +128,12 @@ class User extends Model
         return $this->belongsToMany(Role::class);
     }
     
-    static::pivotAttached(function ($model, $relationName, $pivotIds) {
+    static::pivotAttached(function ($model, $relationName, $pivotIds, $pivotIdsAttributes) {
         echo 'pivotAttached';
         echo get_class($model);
         echo $relationName;
         print_r($pivotIds);
+        print_r($pivotIdsAttributes);
     });
 	
     static::pivotDetached(function ($model, $relationName, $pivotIds) {
@@ -153,7 +154,7 @@ class Role extends Model
 Running this code 
 ```
 $user = User::first();           //assuming that pivot table is empty
-$user->roles()->attach([1, 2]);
+$user->roles()->attach([1, 2 => ['attribute' => 'test']]);
 ```
 
 You will see this output
@@ -163,6 +164,7 @@ pivotAttached
 App\Models\User
 roles
 [1, 2]
+[1 => [], 2 => ['attribute' => 'test']]
 ```
 For attach() or detach() one event is dispatched for both pivot ids.
 

--- a/src/Traits/PivotEventTrait.php
+++ b/src/Traits/PivotEventTrait.php
@@ -58,7 +58,7 @@ trait PivotEventTrait
      * @param  bool  $halt
      * @return mixed
      */
-    public function fireModelEvent($event, $halt = true, $relationName = null, $pivotIds = [])
+    public function fireModelEvent($event, $halt = true, $relationName = null, $pivotIds = [], $pivotIdsAttributes = [])
     {
         if (! isset(static::$dispatcher)) {
             return true;
@@ -77,7 +77,7 @@ trait PivotEventTrait
             return false;
         }
         
-        $payload = ['model' => $this, 'relation' => $relationName, 'pivotIds' => $pivotIds];
+        $payload = ['model' => $this, 'relation' => $relationName, 'pivotIds' => $pivotIds, 'pivotIdsAttributes' => $pivotIdsAttributes];
 
         return ! empty($result) ? $result : static::$dispatcher->{$method}(
             "eloquent.{$event}: ".static::class, $payload

--- a/tests/PivotEventTraitTest.php
+++ b/tests/PivotEventTraitTest.php
@@ -23,7 +23,7 @@ class PivotEventTraitTest extends TestCase
         
         \Event::listen('eloquent.*', function ($eventName, array $data) {
             if (strpos($eventName, 'eloquent.retrieved') !== 0) {
-                self::$events[] = ['name' => $eventName, 'model' => $data['model'], 'relation' => $data['relation'], 'pivotIds' => $data['pivotIds']];
+                self::$events[] = ['name' => $eventName, 'model' => $data['model'], 'relation' => $data['relation'], 'pivotIds' => $data['pivotIds'], 'pivotIdsAttributes' => $data['pivotIdsAttributes']];
             }
         });
     }
@@ -44,10 +44,34 @@ class PivotEventTraitTest extends TestCase
         $this->assertEquals(2, \DB::table('role_user')->count());
         $this->assertNotNull($this->get_from_array(self::$events, 'eloquent.pivotAttaching: ' . User::class, 'name'));
         $this->assertNotNull($this->get_from_array(self::$events, 'eloquent.pivotAttached: ' . User::class, 'name'));
-        
+
         $pivotIds = self::$events[0]['pivotIds'];
         $this->assertEquals($pivotIds, [1, 2]);
-        
+
+        $pivotIdsAttributes = self::$events[0]['pivotIdsAttributes'];
+        $this->assertEquals($pivotIdsAttributes, [1 => [], 2 => []]);
+
+        $this->assertEquals(2, count(self::$events));
+    }
+
+    public function test_attach_multiple_with_attributes_events()
+    {
+        $this->startListening();
+
+        $this->assertEquals(0, \DB::table('role_user')->count());
+        $user = User::find(1);
+        $user->roles()->attach([1 => ['value' => 123], 2 => ['value' => 456]]);
+
+        $this->assertEquals(2, \DB::table('role_user')->count());
+        $this->assertNotNull($this->get_from_array(self::$events, 'eloquent.pivotAttaching: ' . User::class, 'name'));
+        $this->assertNotNull($this->get_from_array(self::$events, 'eloquent.pivotAttached: ' . User::class, 'name'));
+
+        $pivotIds = self::$events[0]['pivotIds'];
+        $this->assertEquals($pivotIds, [1, 2]);
+
+        $pivotIdsAttributes = self::$events[0]['pivotIdsAttributes'];
+        $this->assertEquals($pivotIdsAttributes, [1 => ['value' => 123], 2 => ['value' => 456]]);
+
         $this->assertEquals(2, count(self::$events));
     }
 
@@ -65,8 +89,10 @@ class PivotEventTraitTest extends TestCase
         $this->assertNotNull($this->get_from_array(self::$events, 'eloquent.pivotAttached: ' . User::class, 'name'));
 
         $pivotIds = self::$events[0]['pivotIds'];
-
         $this->assertEquals($pivotIds, [1]);
+
+        $pivotIdsAttributes = self::$events[0]['pivotIdsAttributes'];
+        $this->assertEquals($pivotIdsAttributes, [1 => []]);
 
         $this->assertEquals(2, count(self::$events));
     }
@@ -86,6 +112,9 @@ class PivotEventTraitTest extends TestCase
 
         $pivotIds = self::$events[0]['pivotIds'];
         $this->assertEquals($pivotIds, [1, 2]);
+
+        $pivotIdsAttributes = self::$events[0]['pivotIdsAttributes'];
+        $this->assertEquals($pivotIdsAttributes, [1 => [], 2 => []]);
 
         $this->assertEquals(2, count(self::$events));
     }
@@ -162,6 +191,9 @@ class PivotEventTraitTest extends TestCase
         
         $pivotIds = self::$events[0]['pivotIds'];
         $this->assertEquals($pivotIds, [1]);
+
+        $pivotIdsAttributes = self::$events[0]['pivotIdsAttributes'];
+        $this->assertEquals($pivotIdsAttributes, [1 => ['value' => 2]]);
         
         $this->assertEquals(2, count(self::$events));
     }


### PR DESCRIPTION
I've fixed the issue when attaching / syncing multiple records with attributes, while doing this I thought it would be nice to have those attributes available on the events as a new variable to allow for backwards compatibility.
See Issue #8 

Fixed issue when attach / sync array syntax is used with attributes.
Added attributes variable to be passed on pivotAttaching, pivotAttached, pivotUpdating, pivotUpdated events.
Updated tests and readme