### PR TITLE
Add ability for models to have string Ids

### DIFF
--- a/src/Relations/BelongsToManyCustom.php
+++ b/src/Relations/BelongsToManyCustom.php
@@ -84,7 +84,7 @@ class BelongsToManyCustom extends BelongsToMany
                     $ids[$attributesArray] = $attributes;
                 }
             }
-        } elseif (is_int($id)) {
+        } else {
             $ids[$id] = $attributes;
         }
 

--- a/src/Relations/BelongsToManyCustom.php
+++ b/src/Relations/BelongsToManyCustom.php
@@ -84,7 +84,7 @@ class BelongsToManyCustom extends BelongsToMany
                     $ids[$attributesArray] = $attributes;
                 }
             }
-        } else {
+        } elseif (is_int($id) || is_string($id)) {
             $ids[$id] = $attributes;
         }
 

--- a/tests/Models/Seller.php
+++ b/tests/Models/Seller.php
@@ -2,11 +2,29 @@
 
 namespace Fico7489\Laravel\Pivot\Tests\Models;
 
+use Fico7489\Laravel\Pivot\Traits\PivotEventTrait;
+
 class Seller extends BaseModel
 {
+    use PivotEventTrait;
+
+    public $incrementing = false;
+
     protected $table = 'sellers';
 
     protected $fillable = ['name'];
+
+    /**
+     * Boot the String Id for the model.
+     *
+     * @return void
+     */
+    public static function boot()
+    {
+        static::creating(function ($model) {
+            $model->{$model->getKeyName()} = str_random(255);
+        });
+    }
 
     public function users()
     {

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -17,4 +17,10 @@ class User extends BaseModel
         return $this->belongsToMany(Role::class)
             ->withPivot(['value']);
     }
+
+    public function sellers()
+    {
+        return $this->belongsToMany(Seller::class)
+            ->withPivot(['value']);
+    }
 }

--- a/tests/PivotEventTraitTest.php
+++ b/tests/PivotEventTraitTest.php
@@ -33,12 +33,12 @@ class PivotEventTraitTest extends TestCase
     private function startListening()
     {
         self::$events = [];
-        return User::find(1);
     }
 
     public function test_attach_int()
     {
-        $user = $this->startListening();
+        $this->startListening();
+        $user = User::find(1);
         $user->roles()->attach(1, ['value' => 123]);
 
         $this->check_events(['eloquent.pivotAttaching: ' . User::class, 'eloquent.pivotAttached: ' . User::class]);
@@ -48,7 +48,8 @@ class PivotEventTraitTest extends TestCase
 
     public function test_attach_array()
     {
-        $user = $this->startListening();
+        $this->startListening();
+        $user = User::find(1);
         $user->roles()->attach([1 => ['value' => 123], 2 => ['value' => 456]], ['value2' => 789]);
 
         $this->assertEquals(2, \DB::table('role_user')->count());
@@ -60,7 +61,8 @@ class PivotEventTraitTest extends TestCase
 
     public function test_attach_model()
     {
-        $user = $this->startListening();
+        $this->startListening();
+        $user = User::find(1);
         $role = Role::find(1);
         $user->roles()->attach($role, ['value' => 123]);
 
@@ -72,7 +74,8 @@ class PivotEventTraitTest extends TestCase
 
     public function test_attach_collection()
     {
-        $user = $this->startListening();
+        $this->startListening();
+        $user = User::find(1);
         $roles = Role::take(2)->get();
         $user->roles()->attach($roles, ['value' => 123]);
 
@@ -85,7 +88,8 @@ class PivotEventTraitTest extends TestCase
 
     public function test_detach_int()
     {
-        $user = $this->startListening();
+        $this->startListening();
+        $user = User::find(1);
         $user->roles()->attach([1, 2 ,3]);
         $this->assertEquals(3, \DB::table('role_user')->count());
 
@@ -99,7 +103,8 @@ class PivotEventTraitTest extends TestCase
 
     public function test_detach_array()
     {
-        $user = $this->startListening();
+        $this->startListening();
+        $user = User::find(1);
         $user->roles()->attach([1, 2 ,3]);
         $this->assertEquals(3, \DB::table('role_user')->count());
 
@@ -113,7 +118,8 @@ class PivotEventTraitTest extends TestCase
 
     public function test_detach_model()
     {
-        $user = $this->startListening();
+        $this->startListening();
+        $user = User::find(1);
         $user->roles()->attach([1, 2 ,3]);
         $this->assertEquals(3, \DB::table('role_user')->count());
 
@@ -128,7 +134,8 @@ class PivotEventTraitTest extends TestCase
 
     public function test_detach_collection()
     {
-        $user = $this->startListening();
+        $this->startListening();
+        $user = User::find(1);
         $user->roles()->attach([1, 2 ,3]);
         $this->assertEquals(3, \DB::table('role_user')->count());
 
@@ -143,7 +150,8 @@ class PivotEventTraitTest extends TestCase
 
     public function test_update()
     {
-        $user = $this->startListening();
+        $this->startListening();
+        $user = User::find(1);
         $user->roles()->attach([1, 2 ,3]);
 
         $this->startListening();
@@ -158,7 +166,8 @@ class PivotEventTraitTest extends TestCase
 
     public function test_sync_int()
     {
-        $user = $this->startListening();
+        $this->startListening();
+        $user = User::find(1);
         $user->roles()->attach([2 ,3]);
         $this->assertEquals(2, \DB::table('role_user')->count());
 
@@ -176,7 +185,8 @@ class PivotEventTraitTest extends TestCase
     
     public function test_sync_array()
     {
-        $user = $this->startListening();
+        $this->startListening();
+        $user = User::find(1);
         $user->roles()->attach([2 ,3]);
         $this->assertEquals(2, \DB::table('role_user')->count());
 
@@ -194,7 +204,8 @@ class PivotEventTraitTest extends TestCase
     
     public function test_sync_model()
     {
-        $user = $this->startListening();
+        $this->startListening();
+        $user = User::find(1);
         $user->roles()->attach([2, 3]);
         $this->assertEquals(2, \DB::table('role_user')->count());
 
@@ -213,7 +224,8 @@ class PivotEventTraitTest extends TestCase
 
     public function test_sync_collection()
     {
-        $user = $this->startListening();
+        $this->startListening();
+        $user = User::find(1);
         $user->roles()->attach([1, 2]);
         $this->assertEquals(2, \DB::table('role_user')->count());
 
@@ -236,7 +248,8 @@ class PivotEventTraitTest extends TestCase
 
     public function test_standard_update()
     {
-        $user = $this->startListening();
+        $this->startListening();
+        $user = User::find(1);
         
         $this->startListening();
         $user->update(['name' => 'different']);
@@ -251,7 +264,8 @@ class PivotEventTraitTest extends TestCase
 
     public function test_relation_is_null()
     {
-        $user = $this->startListening();
+        $this->startListening();
+        $user = User::find(1);
         $user->update(['name' => 'new_name']);
 
         $eventName = 'eloquent.updating: ' . User::class;

--- a/tests/database/migrations/2017_11_04_163552_create_database.php
+++ b/tests/database/migrations/2017_11_04_163552_create_database.php
@@ -16,7 +16,7 @@ class CreateDatabase extends Migration
     public function up()
     {
         Schema::create('sellers', function (Blueprint $table) {
-            $table->increments('id');
+            $table->string('id');
             $table->string('name');
 
             $table->timestamps();
@@ -54,8 +54,8 @@ class CreateDatabase extends Migration
             $table->timestamps();
         });
 
-        Schema::create('user_seller', function (Blueprint $table) {
-            $table->integer('seller_id')->unsigned()->index();
+        Schema::create('seller_user', function (Blueprint $table) {
+            $table->string('seller_id')->index();
             $table->integer('user_id')->unsigned()->index();
 
             $table->primary(['seller_id', 'user_id']);


### PR DESCRIPTION
Add ability for models to have string Ids (UUID).
Before this fix $idsOnly and $idsAttributes were returning empty arrays.