### PR TITLE
Halt Actions through Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,10 @@ roles
 [1]
 [1 => ['attribute' => 'test']]
 ```
+## Halting events
+
+To prevent the pivot from attaching, detaching or updating, simply return `false` from within the respective event.
+Note that this will also prevent the `attached`, `detached` or `updated` events from firing.
 
 License
 ----

--- a/src/Relations/BelongsToManyCustom.php
+++ b/src/Relations/BelongsToManyCustom.php
@@ -20,7 +20,10 @@ class BelongsToManyCustom extends BelongsToMany
     {
         list($idsOnly, $idsAttributes) = $this->getIdsWithAttributes($ids, $attributes);
 
-        $this->parent->fireModelEvent('pivotAttaching', true, $this->getRelationName(), $idsOnly, $idsAttributes);
+        if ($this->parent->fireModelEvent('pivotAttaching', true, $this->getRelationName(), $idsOnly, $idsAttributes) === false) {
+            return;
+        }
+
         parent::attach($ids, $attributes, $touch);
         $this->parent->fireModelEvent('pivotAttached', false, $this->getRelationName(), $idsOnly, $idsAttributes);
     }
@@ -36,7 +39,10 @@ class BelongsToManyCustom extends BelongsToMany
     {
         list($idsOnly) = $this->getIdsWithAttributes($ids);
 
-        $this->parent->fireModelEvent('pivotDetaching', true, $this->getRelationName(), $idsOnly);
+        if ($this->parent->fireModelEvent('pivotDetaching', true, $this->getRelationName(), $idsOnly) === false) {
+            return;
+        }
+
         parent::detach($ids, $touch);
         $this->parent->fireModelEvent('pivotDetached', false, $this->getRelationName(), $idsOnly);
     }
@@ -53,7 +59,10 @@ class BelongsToManyCustom extends BelongsToMany
     {
         list($idsOnly, $idsAttributes) = $this->getIdsWithAttributes($id, $attributes);
 
-        $this->parent->fireModelEvent('pivotUpdating', true, $this->getRelationName(), $idsOnly, $idsAttributes);
+        if ($this->parent->fireModelEvent('pivotUpdating', true, $this->getRelationName(), $idsOnly, $idsAttributes) === false) {
+            return;
+        }
+
         parent::updateExistingPivot($id, $attributes, $touch);
         $this->parent->fireModelEvent('pivotUpdated', false, $this->getRelationName(), $idsOnly, $idsAttributes);
     }


### PR DESCRIPTION
Returning `false` from within the `attaching`, `detaching` or `updating` event will prevent the respective change from going through.