### PR TITLE
Fix detach method when called without IDs

### DIFF
--- a/src/Relations/BelongsToManyCustom.php
+++ b/src/Relations/BelongsToManyCustom.php
@@ -34,6 +34,10 @@ class BelongsToManyCustom extends BelongsToMany
      */
     public function detach($ids = null, $touch = true)
     {
+        if (is_null($ids)) {
+            $ids = $this->query->pluck($this->query->qualifyColumn('id'))->toArray();
+        }
+
         list($idsOnly) = $this->getIdsWithAttributes($ids);
 
         $this->parent->fireModelEvent('pivotDetaching', true, $this->getRelationName(), $idsOnly);

--- a/src/Relations/BelongsToManyCustom.php
+++ b/src/Relations/BelongsToManyCustom.php
@@ -35,7 +35,7 @@ class BelongsToManyCustom extends BelongsToMany
     public function detach($ids = null, $touch = true)
     {
         if (is_null($ids)) {
-            $ids = $this->query->pluck($this->query->qualifyColumn('id'))->toArray();
+            $ids = $this->query->pluck($this->query->qualifyColumn($this->relatedKey))->toArray();
         }
 
         list($idsOnly) = $this->getIdsWithAttributes($ids);

--- a/src/Relations/BelongsToManyCustom.php
+++ b/src/Relations/BelongsToManyCustom.php
@@ -32,7 +32,7 @@ class BelongsToManyCustom extends BelongsToMany
      * @param  bool  $touch
      * @return int
      */
-    public function detach($ids = [], $touch = true)
+    public function detach($ids = null, $touch = true)
     {
         list($idsOnly) = $this->getIdsWithAttributes($ids);
 

--- a/tests/PivotEventTraitTest.php
+++ b/tests/PivotEventTraitTest.php
@@ -164,6 +164,21 @@ class PivotEventTraitTest extends TestCase
         $this->check_variables(0, [1, 2]);
     }
 
+    public function test_detach_null()
+    {
+        $this->startListening();
+        $user = User::find(1);
+        $user->roles()->attach([1, 2 ,3]);
+        $this->assertEquals(3, \DB::table('role_user')->count());
+
+        $this->startListening();
+        $user->roles()->detach();
+
+        $this->assertEquals(0, \DB::table('role_user')->count());
+        $this->check_events(['eloquent.pivotDetaching: ' . User::class, 'eloquent.pivotDetached: ' . User::class]);
+        $this->check_variables(0, []);
+    }
+
     public function test_update()
     {
         $this->startListening();

--- a/tests/PivotEventTraitTest.php
+++ b/tests/PivotEventTraitTest.php
@@ -176,7 +176,7 @@ class PivotEventTraitTest extends TestCase
 
         $this->assertEquals(0, \DB::table('role_user')->count());
         $this->check_events(['eloquent.pivotDetaching: ' . User::class, 'eloquent.pivotDetached: ' . User::class]);
-        $this->check_variables(0, []);
+        $this->check_variables(0, [1, 2, 3]);
     }
 
     public function test_update()


### PR DESCRIPTION
See https://github.com/fico7489/laravel-pivot/issues/21