### PR TITLE
Use index based event payload instead of associative array

### DIFF
--- a/src/Traits/ExtendFireModelEventTrait.php
+++ b/src/Traits/ExtendFireModelEventTrait.php
@@ -30,7 +30,7 @@ trait ExtendFireModelEventTrait
             return false;
         }
 
-        $payload = ['model' => $this, 'relation' => $relationName, 'pivotIds' => $ids, 'pivotIdsAttributes' => $idsAttributes];
+        $payload = [$this, $relationName, $ids, $idsAttributes];
 
         return ! empty($result) ? $result : static::$dispatcher->{$method}(
             "eloquent.{$event}: ".static::class, $payload

--- a/tests/PivotEventTraitTest.php
+++ b/tests/PivotEventTraitTest.php
@@ -29,7 +29,7 @@ class PivotEventTraitTest extends TestCase
 
         \Event::listen('eloquent.*', function ($eventName, array $data) {
             if (strpos($eventName, 'eloquent.retrieved') !== 0) {
-                self::$events[] = ['name' => $eventName, 'model' => $data['model'], 'relation' => $data['relation'], 'pivotIds' => $data['pivotIds'], 'pivotIdsAttributes' => $data['pivotIdsAttributes']];
+                self::$events[] = array_merge([$eventName], $data);
             }
         });
     }
@@ -307,7 +307,7 @@ class PivotEventTraitTest extends TestCase
     {
         $i = 0;
         foreach ($events as $event) {
-            $this->assertEquals(self::$events[$i]['name'], $event);
+            $this->assertEquals(self::$events[$i][0], $event);
             $i++;
         }
         $this->assertEquals(count($events), count(self::$events));
@@ -315,9 +315,9 @@ class PivotEventTraitTest extends TestCase
 
     private function check_variables($number, $ids, $idsAttributes = [], $relation = 'roles')
     {
-        $this->assertEquals(self::$events[$number]['pivotIds'], $ids);
-        $this->assertEquals(self::$events[$number]['pivotIdsAttributes'], $idsAttributes);
-        $this->assertEquals(self::$events[$number]['relation'], $relation);
+        $this->assertEquals(self::$events[$number][2], $relation);
+        $this->assertEquals(self::$events[$number][3], $ids);
+        $this->assertEquals(self::$events[$number][4], $idsAttributes);
     }
 
     private function check_database($count, $value, $number = 0, $attribute = 'value', $table = 'role_user')


### PR DESCRIPTION
Using associative arrays in the dispatcher conflicts with [itsgoingd/clockwork](https://github.com/itsgoingd/clockwork). Because Observers just use the order of the payload array, it seems reasonable to pass the payload as an ordered array, instead of associative.

Another concern is that the tests would still pass if the order of the array would be changed, while still using the correct array keys. However, this would change the perceived behaviour in the Observers, as they use only the order of the payload. 