### PR TITLE
modification of the attachements by the listeners

### DIFF
--- a/src/Traits/ExtendFireModelEventTrait.php
+++ b/src/Traits/ExtendFireModelEventTrait.php
@@ -11,7 +11,7 @@ trait ExtendFireModelEventTrait
      * @param  bool  $halt
      * @return mixed
      */
-    public function fireModelEvent($event, $halt = true, $relationName = null, $ids = [], $idsAttributes = [])
+    public function fireModelEvent($event, $halt = true, $relationName = null, $ids = [], &$idsAttributes = [])
     {
         if (! isset(static::$dispatcher)) {
             return true;
@@ -30,7 +30,8 @@ trait ExtendFireModelEventTrait
             return false;
         }
 
-        $payload = ['model' => $this, 'relation' => $relationName, 'pivotIds' => $ids, 'pivotIdsAttributes' => $idsAttributes];
+        $payload = ['model' => $this, 'relation' => $relationName, 'pivotIds' => $ids];
+        $payload['pivotIdsAttributes'] => &$idsAttributes;
 
         return ! empty($result) ? $result : static::$dispatcher->{$method}(
             "eloquent.{$event}: ".static::class, $payload


### PR DESCRIPTION
This would allow the attachments to be modified by the pivotAttaching listeners so that we can easily add attributes like userstamp to the pivot tables.
Example: 


	Class Attaching{
		public function handle($model, $relationName, $pivotIds, &$pivotIdsAttributes)
		{
			if (! $model -> isPivotUserstamping()) {
				return;
			}

			foreach($pivotIdsAttributes as $id => &$attributes){
				$attributes['created_by'] = auth() -> id();
				$attributes['updated_by'] = auth() -> id();
			}
		}
	}