### PR TITLE
Events for MorphToMany relations

### DIFF
--- a/src/Relations/MorphToManyCustom.php
+++ b/src/Relations/MorphToManyCustom.php
@@ -2,10 +2,10 @@
 
 namespace Fico7489\Laravel\Pivot\Relations;
 
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Fico7489\Laravel\Pivot\Traits\FiresPivotEventsTrait;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
-class BelongsToManyCustom extends BelongsToMany
+class MorphToManyCustom extends MorphToMany
 {
     use FiresPivotEventsTrait;
 }

--- a/src/Traits/ExtendFireModelEventTrait.php
+++ b/src/Traits/ExtendFireModelEventTrait.php
@@ -33,7 +33,7 @@ trait ExtendFireModelEventTrait
         $payload = ['model' => $this, 'relation' => $relationName, 'pivotIds' => $ids, 'pivotIdsAttributes' => $idsAttributes];
 
         return ! empty($result) ? $result : static::$dispatcher->{$method}(
-            "eloquent.{$event}: ".static::class, $payload
+            "eloquent.{$event}: " . static::class, $payload
         );
     }
 }

--- a/src/Traits/ExtendMorphToManyTrait.php
+++ b/src/Traits/ExtendMorphToManyTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Fico7489\Laravel\Pivot\Traits;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Fico7489\Laravel\Pivot\Relations\MorphToManyCustom;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+
+trait ExtendMorphToManyTrait
+{
+    /**
+     * Instantiate a new MorphToMany relationship.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  string  $name
+     * @param  string  $table
+     * @param  string  $foreignPivotKey
+     * @param  string  $relatedPivotKey
+     * @param  string  $parentKey
+     * @param  string  $relatedKey
+     * @param  string  $relationName
+     * @param  bool  $inverseE
+     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
+     */
+    protected function newMorphToMany(Builder $query, Model $parent, $name, $table, $foreignPivotKey,
+                                      $relatedPivotKey, $parentKey, $relatedKey,
+                                      $relationName = null, $inverse = false)
+    {
+        return new MorphToManyCustom($query, $parent, $name, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey,
+            $relationName, $inverse);
+    }
+}

--- a/src/Traits/FiresPivotEventsTrait.php
+++ b/src/Traits/FiresPivotEventsTrait.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Fico7489\Laravel\Pivot\Traits;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
+
+trait FiresPivotEventsTrait
+{
+    /**
+         * Attach a model to the parent.
+         *
+         * @param  mixed  $id
+         * @param  array  $attributes
+         * @param  bool   $touch
+         * @return void
+         */
+    public function attach($ids, array $attributes = [], $touch = true)
+    {
+        list($idsOnly, $idsAttributes) = $this->getIdsWithAttributes($ids, $attributes);
+
+        $this->parent->fireModelEvent('pivotAttaching', true, $this->getRelationName(), $idsOnly, $idsAttributes);
+        $parentResult = parent::attach($ids, $attributes, $touch);
+        $this->parent->fireModelEvent('pivotAttached', false, $this->getRelationName(), $idsOnly, $idsAttributes);
+
+        return $parentResult;
+    }
+
+    /**
+     * Detach models from the relationship.
+     *
+     * @param  mixed  $ids
+     * @param  bool  $touch
+     * @return int
+     */
+    public function detach($ids = null, $touch = true)
+    {
+        if (is_null($ids)) {
+            $ids = $this->query->pluck($this->query->qualifyColumn($this->relatedKey))->toArray();
+        }
+
+        list($idsOnly) = $this->getIdsWithAttributes($ids);
+
+        $this->parent->fireModelEvent('pivotDetaching', true, $this->getRelationName(), $idsOnly);
+        $parentResult = parent::detach($ids, $touch);
+        $this->parent->fireModelEvent('pivotDetached', false, $this->getRelationName(), $idsOnly);
+
+        return $parentResult;
+    }
+
+    /**
+     * Update an existing pivot record on the table.
+     *
+     * @param  mixed  $id
+     * @param  array  $attributes
+     * @param  bool   $touch
+     * @return int
+     */
+    public function updateExistingPivot($id, array $attributes, $touch = true)
+    {
+        list($idsOnly, $idsAttributes) = $this->getIdsWithAttributes($id, $attributes);
+
+        $this->parent->fireModelEvent('pivotUpdating', true, $this->getRelationName(), $idsOnly, $idsAttributes);
+        $parentResult = parent::updateExistingPivot($id, $attributes, $touch);
+        $this->parent->fireModelEvent('pivotUpdated', false, $this->getRelationName(), $idsOnly, $idsAttributes);
+
+        return $parentResult;
+    }
+
+    /**
+     * Cleans the ids and ids with attributes
+     * Returns an array with and array of ids and array of id => attributes
+     *
+     * @param  mixed  $id
+     * @param  array  $attributes
+     * @return array
+     */
+    private function getIdsWithAttributes($id, $attributes = [])
+    {
+        $ids = [];
+
+        if ($id instanceof Model) {
+            $ids[$id->getKey()] = $attributes;
+        } elseif ($id instanceof Collection) {
+            foreach ($id as $model) {
+                $ids[$model->getKey()] = $attributes;
+            }
+        } elseif (is_array($id)) {
+            foreach ($id as $key => $attributesArray) {
+                if (is_array($attributesArray)) {
+                    $ids[$key] = array_merge($attributes, $attributesArray);
+                } else {
+                    $ids[$attributesArray] = $attributes;
+                }
+            }
+        } elseif (is_int($id) || is_string($id)) {
+            $ids[$id] = $attributes;
+        }
+
+        $idsOnly = array_keys($ids);
+
+        return [$idsOnly, $ids];
+    }
+}

--- a/src/Traits/PivotEventTrait.php
+++ b/src/Traits/PivotEventTrait.php
@@ -5,6 +5,7 @@ namespace Fico7489\Laravel\Pivot\Traits;
 trait PivotEventTrait
 {
     use ExtendBelongsToManyTrait;
+    use ExtendMorphToManyTrait;
     use ExtendFireModelEventTrait;
 
     public static function pivotAttaching($callback, $priority = 0)

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Fico7489\Laravel\Pivot\Tests\Models;
+
+use Fico7489\Laravel\Pivot\Traits\PivotEventTrait;
+
+class Post extends BaseModel
+{
+    use PivotEventTrait;
+
+    protected $table = 'posts';
+
+    protected $fillable = ['name'];
+
+    public function tags()
+    {
+        return $this->morphToMany(Tag::class, 'taggable');
+    }
+}

--- a/tests/Models/Tag.php
+++ b/tests/Models/Tag.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Fico7489\Laravel\Pivot\Tests\Models;
+
+use Fico7489\Laravel\Pivot\Traits\PivotEventTrait;
+
+class Tag extends BaseModel
+{
+    use PivotEventTrait;
+
+    protected $table = 'videos';
+
+    protected $fillable = ['name'];
+
+    public function posts()
+    {
+        return $this->morphedByMany(Post::class, 'taggable');
+    }
+
+    public function videos()
+    {
+        return $this->morphedByMany(Video::class, 'taggable');
+    }
+}

--- a/tests/Models/Video.php
+++ b/tests/Models/Video.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Fico7489\Laravel\Pivot\Tests\Models;
+
+use Fico7489\Laravel\Pivot\Traits\PivotEventTrait;
+
+class Video extends BaseModel
+{
+    use PivotEventTrait;
+
+    protected $table = 'videos';
+
+    protected $fillable = ['name'];
+
+    public function tags()
+    {
+        return $this->morphToMany(Tag::class, 'taggable');
+    }
+}

--- a/tests/PivotEventTraitTest.php
+++ b/tests/PivotEventTraitTest.php
@@ -2,9 +2,12 @@
 
 namespace Fico7489\Laravel\Pivot\Tests;
 
+use Fico7489\Laravel\Pivot\Tests\Models\Tag;
+use Fico7489\Laravel\Pivot\Tests\Models\Post;
 use Fico7489\Laravel\Pivot\Tests\Models\Role;
-use Fico7489\Laravel\Pivot\Tests\Models\Seller;
 use Fico7489\Laravel\Pivot\Tests\Models\User;
+use Fico7489\Laravel\Pivot\Tests\Models\Video;
+use Fico7489\Laravel\Pivot\Tests\Models\Seller;
 
 class PivotEventTraitTest extends TestCase
 {
@@ -24,8 +27,19 @@ class PivotEventTraitTest extends TestCase
         Role::create(['name' => 'customer']);
         Role::create(['name' => 'driver']);
 
+        Post::create(['name' => 'Learn Laravel in 30 days']);
+        Post::create(['name' => 'Vue.js for Dummies']);
+
+        Video::create(['name' => 'Laravel from Scratch']);
+        Video::create(['name' => 'ES2015 Fundamentals']);
+
+        Tag::create(['name' => 'technology']);
+        Tag::create(['name' => 'laravel']);
+        Tag::create(['name' => 'java-script']);
+
         $this->assertEquals(0, \DB::table('role_user')->count());
         $this->assertEquals(0, \DB::table('seller_user')->count());
+        $this->assertEquals(0, \DB::table('taggables')->count());
 
         \Event::listen('eloquent.*', function ($eventName, array $data) {
             if (strpos($eventName, 'eloquent.retrieved') !== 0) {
@@ -48,6 +62,17 @@ class PivotEventTraitTest extends TestCase
         $this->check_events(['eloquent.pivotAttaching: ' . User::class, 'eloquent.pivotAttached: ' . User::class]);
         $this->check_variables(0, [1], [1 => ['value' => 123]]);
         $this->check_database(1, 123, 0, 'value');
+    }
+
+    public function test_polymorphic_attach_int()
+    {
+        $this->startListening();
+        $post = Post::find(1);
+        $post->tags()->attach(1, ['value' => 123]);
+
+        $this->check_events(['eloquent.pivotAttaching: ' . Post::class, 'eloquent.pivotAttached: ' . Post::class]);
+        $this->check_variables(0, [1], [1 => ['value' => 123]], 'tags');
+        $this->check_database(1, 123, 0, 'value', 'taggables');
     }
 
     public function test_attach_string()
@@ -75,6 +100,19 @@ class PivotEventTraitTest extends TestCase
         $this->check_database(2, 789, 0, 'value2');
     }
 
+    public function test_polymorphic_attach_array()
+    {
+        $this->startListening();
+        $video = Video::find(1);
+        $video->tags()->attach([1 => ['value' => 123], 2 => ['value' => 456]], ['value2' => 789]);
+
+        $this->assertEquals(2, \DB::table('taggables')->count());
+        $this->check_events(['eloquent.pivotAttaching: ' . Video::class, 'eloquent.pivotAttached: ' . Video::class]);
+        $this->check_variables(0, [1, 2], [1 => ['value' => 123, 'value2' => 789], 2 => ['value' => 456, 'value2' => 789]], 'tags');
+        $this->check_database(2, 123, 0, 'value', 'taggables');
+        $this->check_database(2, 789, 0, 'value2', 'taggables');
+    }
+
     public function test_attach_model()
     {
         $this->startListening();
@@ -86,6 +124,19 @@ class PivotEventTraitTest extends TestCase
         $this->check_events(['eloquent.pivotAttaching: ' . User::class, 'eloquent.pivotAttached: ' . User::class]);
         $this->check_variables(0, [1], [1 => ['value' => 123]]);
         $this->check_database(1, 123);
+    }
+
+    public function test_polymorphic_attach_model()
+    {
+        $this->startListening();
+        $tag = Tag::find(1);
+        $video = Video::find(1);
+        $tag->videos()->attach($video, ['value' => 123]);
+
+        $this->assertEquals(1, \DB::table('taggables')->count());
+        $this->check_events(['eloquent.pivotAttaching: ' . Tag::class, 'eloquent.pivotAttached: ' . Tag::class]);
+        $this->check_variables(0, [1], [1 => ['value' => 123]], 'videos');
+        $this->check_database(1, 123, 0, 'value', 'taggables');
     }
 
     public function test_attach_collection()
@@ -102,11 +153,25 @@ class PivotEventTraitTest extends TestCase
         $this->check_database(2, 123, 1);
     }
 
+    public function test_polymorphic_attach_collection()
+    {
+        $this->startListening();
+        $post = Post::find(1);
+        $tags = Tag::take(2)->get();
+        $post->tags()->attach($tags, ['value' => 123]);
+
+        $this->assertEquals(2, \DB::table('taggables')->count());
+        $this->check_events(['eloquent.pivotAttaching: ' . Post::class, 'eloquent.pivotAttached: ' . Post::class]);
+        $this->check_variables(0, [1, 2], [1 => ['value' => 123], 2 => ['value' => 123]], 'tags');
+        $this->check_database(2, 123, 0, 'value', 'taggables');
+        $this->check_database(2, 123, 1, 'value', 'taggables');
+    }
+
     public function test_detach_int()
     {
         $this->startListening();
         $user = User::find(1);
-        $user->roles()->attach([1, 2 ,3]);
+        $user->roles()->attach([1, 2, 3]);
         $this->assertEquals(3, \DB::table('role_user')->count());
 
         $this->startListening();
@@ -117,11 +182,26 @@ class PivotEventTraitTest extends TestCase
         $this->check_variables(0, [2]);
     }
 
+    public function test_polymorphic_detach_int()
+    {
+        $this->startListening();
+        $video = Video::find(1);
+        $video->tags()->attach([1, 2, 3]);
+        $this->assertEquals(3, \DB::table('taggables')->count());
+
+        $this->startListening();
+        $video->tags()->detach(2);
+
+        $this->assertEquals(2, \DB::table('taggables')->count());
+        $this->check_events(['eloquent.pivotDetaching: ' . Video::class, 'eloquent.pivotDetached: ' . Video::class]);
+        $this->check_variables(0, [2], [], 'tags');
+    }
+
     public function test_detach_array()
     {
         $this->startListening();
         $user = User::find(1);
-        $user->roles()->attach([1, 2 ,3]);
+        $user->roles()->attach([1, 2, 3]);
         $this->assertEquals(3, \DB::table('role_user')->count());
 
         $this->startListening();
@@ -132,11 +212,26 @@ class PivotEventTraitTest extends TestCase
         $this->check_variables(0, [2, 3]);
     }
 
+    public function test_polymorphic_detach_array()
+    {
+        $this->startListening();
+        $post = Post::find(1);
+        $post->tags()->attach([1, 2, 3]);
+        $this->assertEquals(3, \DB::table('taggables')->count());
+
+        $this->startListening();
+        $post->tags()->detach([2, 3]);
+
+        $this->assertEquals(1, \DB::table('taggables')->count());
+        $this->check_events(['eloquent.pivotDetaching: ' . Post::class, 'eloquent.pivotDetached: ' . Post::class]);
+        $this->check_variables(0, [2, 3], [], 'tags');
+    }
+
     public function test_detach_model()
     {
         $this->startListening();
         $user = User::find(1);
-        $user->roles()->attach([1, 2 ,3]);
+        $user->roles()->attach([1, 2, 3]);
         $this->assertEquals(3, \DB::table('role_user')->count());
 
         $this->startListening();
@@ -148,11 +243,29 @@ class PivotEventTraitTest extends TestCase
         $this->check_variables(0, [1]);
     }
 
+    public function test_polymorphic_detach_model()
+    {
+        $this->startListening();
+        $post = Post::find(1);
+        $video = Video::find(1);
+        $post->tags()->attach([1, 2]);
+        $video->tags()->attach([2]);
+        $this->assertEquals(3, \DB::table('taggables')->count());
+
+        $this->startListening();
+        $tag = Tag::find(2);
+        $tag->videos()->detach($video);
+
+        $this->assertEquals(2, \DB::table('taggables')->count());
+        $this->check_events(['eloquent.pivotDetaching: ' . Tag::class, 'eloquent.pivotDetached: ' . Tag::class]);
+        $this->check_variables(0, [1], [], 'videos');
+    }
+
     public function test_detach_collection()
     {
         $this->startListening();
         $user = User::find(1);
-        $user->roles()->attach([1, 2 ,3]);
+        $user->roles()->attach([1, 2, 3]);
         $this->assertEquals(3, \DB::table('role_user')->count());
 
         $this->startListening();
@@ -164,11 +277,27 @@ class PivotEventTraitTest extends TestCase
         $this->check_variables(0, [1, 2]);
     }
 
+    public function test_polymorphic_detach_collection()
+    {
+        $this->startListening();
+        $post = Post::find(1);
+        $post->tags()->attach([1, 2, 3]);
+        $this->assertEquals(3, \DB::table('taggables')->count());
+
+        $this->startListening();
+        $tags = Tag::take(2)->get();
+        $post->tags()->detach($tags);
+
+        $this->assertEquals(1, \DB::table('taggables')->count());
+        $this->check_events(['eloquent.pivotDetaching: ' . Post::class, 'eloquent.pivotDetached: ' . Post::class]);
+        $this->check_variables(0, [1, 2], [], 'tags');
+    }
+
     public function test_detach_null()
     {
         $this->startListening();
         $user = User::find(1);
-        $user->roles()->attach([1, 2 ,3]);
+        $user->roles()->attach([1, 2, 3]);
         $this->assertEquals(3, \DB::table('role_user')->count());
 
         $this->startListening();
@@ -179,11 +308,28 @@ class PivotEventTraitTest extends TestCase
         $this->check_variables(0, [1, 2, 3]);
     }
 
+    public function test_polymorphic_detach_null()
+    {
+        $this->startListening();
+        $post = Post::find(1);
+        $post->tags()->attach([1, 2]);
+        $video = Video::find(2);
+        $video->tags()->attach([2, 3]);
+        $this->assertEquals(4, \DB::table('taggables')->count());
+
+        $this->startListening();
+        $post->tags()->detach();
+
+        $this->assertEquals(2, \DB::table('taggables')->count());
+        $this->check_events(['eloquent.pivotDetaching: ' . Post::class, 'eloquent.pivotDetached: ' . Post::class]);
+        $this->check_variables(0, [1, 2], [], 'tags');
+    }
+
     public function test_update()
     {
         $this->startListening();
         $user = User::find(1);
-        $user->roles()->attach([1, 2 ,3]);
+        $user->roles()->attach([1, 2, 3]);
 
         $this->startListening();
         $user->roles()->updateExistingPivot(1, ['value' => 123]);
@@ -195,11 +341,27 @@ class PivotEventTraitTest extends TestCase
         $this->check_database(3, null, 2);
     }
 
+    public function test_polymorphic_update()
+    {
+        $this->startListening();
+        $video = Video::find(1);
+        $video->tags()->attach([1, 2, 3]);
+
+        $this->startListening();
+        $video->tags()->updateExistingPivot(1, ['value' => 123]);
+
+        $this->assertEquals(3, \DB::table('taggables')->count());
+        $this->check_events(['eloquent.pivotUpdating: ' . Video::class, 'eloquent.pivotUpdated: ' . Video::class]);
+        $this->check_variables(0, [1], [1 => ['value' => 123]], 'tags');
+        $this->check_database(3, 123, 0, 'value', 'taggables');
+        $this->check_database(3, null, 2, 'value', 'taggables');
+    }
+
     public function test_sync_int()
     {
         $this->startListening();
         $user = User::find(1);
-        $user->roles()->attach([2 ,3]);
+        $user->roles()->attach([2, 3]);
         $this->assertEquals(2, \DB::table('role_user')->count());
 
         $this->startListening();
@@ -213,12 +375,31 @@ class PivotEventTraitTest extends TestCase
             'eloquent.pivotAttached: ' . User::class,
         ]);
     }
-    
+
+    public function test_polymorphic_sync_int()
+    {
+        $this->startListening();
+        $post = Post::find(1);
+        $post->tags()->attach([2, 3]);
+        $this->assertEquals(2, \DB::table('taggables')->count());
+
+        $this->startListening();
+        $post->tags()->sync(1);
+
+        $this->assertEquals(1, \DB::table('taggables')->count());
+        $this->check_events([
+            'eloquent.pivotDetaching: ' . Post::class,
+            'eloquent.pivotDetached: ' . Post::class,
+            'eloquent.pivotAttaching: ' . Post::class,
+            'eloquent.pivotAttached: ' . Post::class,
+        ]);
+    }
+
     public function test_sync_array()
     {
         $this->startListening();
         $user = User::find(1);
-        $user->roles()->attach([2 ,3]);
+        $user->roles()->attach([2, 3]);
         $this->assertEquals(2, \DB::table('role_user')->count());
 
         $this->startListening();
@@ -232,7 +413,26 @@ class PivotEventTraitTest extends TestCase
             'eloquent.pivotAttached: ' . User::class,
         ]);
     }
-    
+
+    public function test_polymorphic_sync_array()
+    {
+        $this->startListening();
+        $video = Video::find(1);
+        $video->tags()->attach([2, 3]);
+        $this->assertEquals(2, \DB::table('taggables')->count());
+
+        $this->startListening();
+        $video->tags()->sync([1]);
+
+        $this->assertEquals(1, \DB::table('taggables')->count());
+        $this->check_events([
+            'eloquent.pivotDetaching: ' . Video::class,
+            'eloquent.pivotDetached: ' . Video::class,
+            'eloquent.pivotAttaching: ' . Video::class,
+            'eloquent.pivotAttached: ' . Video::class,
+        ]);
+    }
+
     public function test_sync_model()
     {
         $this->startListening();
@@ -249,6 +449,28 @@ class PivotEventTraitTest extends TestCase
             'eloquent.pivotDetached: ' . User::class,
             'eloquent.pivotAttaching: ' . User::class,
             'eloquent.pivotAttached: ' . User::class,
+        ]);
+        $this->assertEquals(4, count(self::$events));
+    }
+
+    public function test_polymorphic_sync_model()
+    {
+        $this->startListening();
+        $video = Video::find(1);
+        $video->tags()->attach([2, 3]);
+        $this->assertEquals(2, \DB::table('taggables')->count());
+
+        $this->startListening();
+        $tag = Tag::find(1);
+        $video->tags()->sync($tag);
+
+        $this->assertEquals(1, \DB::table('taggables')->count());
+
+        $this->check_events([
+            'eloquent.pivotDetaching: ' . Video::class,
+            'eloquent.pivotDetached: ' . Video::class,
+            'eloquent.pivotAttaching: ' . Video::class,
+            'eloquent.pivotAttached: ' . Video::class,
         ]);
         $this->assertEquals(4, count(self::$events));
     }
@@ -277,11 +499,33 @@ class PivotEventTraitTest extends TestCase
         $this->check_variables(4, [4], [4 => []]);
     }
 
+    public function test_polymorphic_sync_collection()
+    {
+        $this->startListening();
+        $tag = Tag::find(1);
+        $tag->posts()->attach([1]);
+        $tag->videos()->attach([2]);
+        $this->assertEquals(2, \DB::table('taggables')->count());
+
+        $this->startListening();
+        $posts = Post::where('id', 2)->get();
+        $tag->posts()->sync($posts);
+
+        $this->check_events([
+            'eloquent.pivotDetaching: ' . Tag::class,
+            'eloquent.pivotDetached: ' . Tag::class,
+            'eloquent.pivotAttaching: ' . Tag::class,
+            'eloquent.pivotAttached: ' . Tag::class,
+        ]);
+        $this->check_variables(0, [1], [], 'posts');
+        $this->check_variables(2, [2], [2 => []], 'posts');
+    }
+
     public function test_standard_update()
     {
         $this->startListening();
         $user = User::find(1);
-        
+
         $this->startListening();
         $user->update(['name' => 'different']);
 

--- a/tests/database/migrations/2017_11_04_163552_create_database.php
+++ b/tests/database/migrations/2017_11_04_163552_create_database.php
@@ -1,7 +1,7 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 /**
  * Class CreateDatabase
@@ -70,6 +70,36 @@ class CreateDatabase extends Migration
 
             $table->timestamps();
         });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+
+            $table->timestamps();
+        });
+
+        Schema::create('videos', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+
+            $table->timestamps();
+        });
+
+        Schema::create('tags', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+
+            $table->timestamps();
+        });
+
+        Schema::create('taggables', function (Blueprint $table) {
+            $table->unsignedInteger('tag_id');
+            $table->unsignedInteger('taggable_id');
+            $table->string('taggable_type');
+
+            $table->integer('value')->nullable();
+            $table->integer('value2')->nullable();
+        });
     }
 
     /**
@@ -84,5 +114,9 @@ class CreateDatabase extends Migration
         Schema::drop('users');
         Schema::drop('roles');
         Schema::drop('sellers');
+        Schema::drop('posts');
+        Schema::drop('videos');
+        Schema::drop('tags');
+        Schema::drop('taggables');
     }
 }


### PR DESCRIPTION
This PR adds events for MorphToMany relations, fixing issues [#33](https://github.com/fico7489/laravel-pivot/issues/33) and [#34](https://github.com/fico7489/laravel-pivot/issues/34)

I don't think the code is not organized perfectly after adding this feature (in particular in tests), and I am happy to work on improving it if necessary. Just please take a look and let me know it adding MorphToMany is something you want to do.

I'm PRing it to 2.1, since Laravel 5.5 is LTS.
