### PR TITLE
Fix for Laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "illuminate/database": "5.6.*"
+        "illuminate/database": "5.7.*"
     },
     "require-dev": {
         "orchestra/testbench": "3.6.*",

--- a/src/Traits/PivotEventTrait.php
+++ b/src/Traits/PivotEventTrait.php
@@ -8,17 +8,13 @@ trait PivotEventTrait
     use ExtendMorphToManyTrait;
     use ExtendFireModelEventTrait;
 
-    public static function boot()
+    public function initializePivotEventTrait()
     {
-        parent::boot();
-
-        app('events')->listen('eloquent.booted: '.static::class, function ($model) {
-            $model->addObservableEvents([
-                'pivotAttaching', 'pivotAttached',
-                'pivotDetaching', 'pivotDetached',
-                'pivotUpdating', 'pivotUpdated',
-            ]);
-        });
+        $this->addObservableEvents([
+            'pivotAttaching', 'pivotAttached',
+            'pivotDetaching', 'pivotDetached',
+            'pivotUpdating', 'pivotUpdated',
+        ]);
     }
 
     public static function pivotAttaching($callback, $priority = 0)


### PR DESCRIPTION
The issue with this in 5.7 is that you can't call `addObservableEvents` after `eloquent.booted` anymore, as it's too late.

I made use of the new `initialize` method on traits to call `addObservableEvents` during trait initialization - this seems to work fine in my testing!