### PR TITLE
Upgrade to Laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,44 +1,44 @@
 {
-    "name": "fico7489/laravel-pivot",
-    "description": "This package introduces new eloquent events for sync(), attach(), detach() or updateExistingPivot() methods on BelongsToMany relation.",
-    "keywords": [
-        "laravel BelongsToMany events",
-        "eloquent extra events",
-        "laravel pivot events",
-        "laravel sync events",
-        "eloquent events"
-    ],
-    "homepage": "https://github.com/fico7489/laravel-pivot",
-    "support": {
-        "issues": "https://github.com/fico7489/laravel-pivot/issues",
-        "source": "https://github.com/fico7489/laravel-pivot"
-    },
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Filip Horvat",
-            "email": "filip.horvat@am2studio.hr",
-            "homepage": "http://am2studio.hr",
-            "role": "Developer"
-        }
-    ],
-    "require": {
-        "illuminate/database": "5.6.*"
-    },
-    "require-dev": {
-        "orchestra/testbench": "3.6.*",
-        "friendsofphp/php-cs-fixer": "2.*"
-    },
-    "autoload": {
-        "psr-4": {
-            "Fico7489\\Laravel\\Pivot\\": "src"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Fico7489\\Laravel\\Pivot\\Tests\\": "tests/"
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+  "name": "fico7489/laravel-pivot",
+  "description": "This package introduces new eloquent events for sync(), attach(), detach() or updateExistingPivot() methods on BelongsToMany relation.",
+  "keywords": [
+    "laravel BelongsToMany events",
+    "eloquent extra events",
+    "laravel pivot events",
+    "laravel sync events",
+    "eloquent events"
+  ],
+  "homepage": "https://github.com/fico7489/laravel-pivot",
+  "support": {
+    "issues": "https://github.com/fico7489/laravel-pivot/issues",
+    "source": "https://github.com/fico7489/laravel-pivot"
+  },
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Filip Horvat",
+      "email": "filip.horvat@am2studio.hr",
+      "homepage": "http://am2studio.hr",
+      "role": "Developer"
+    }
+  ],
+  "require": {
+    "illuminate/database": "5.7.*"
+  },
+  "require-dev": {
+    "orchestra/testbench": "3.7.*",
+    "friendsofphp/php-cs-fixer": "2.*"
+  },
+  "autoload": {
+    "psr-4": {
+      "Fico7489\\Laravel\\Pivot\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Fico7489\\Laravel\\Pivot\\Tests\\": "tests/"
+    }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/tests/Models/Seller.php
+++ b/tests/Models/Seller.php
@@ -17,8 +17,10 @@ class Seller extends BaseModel
     /**
      * Boot the String Id for the model.
      */
-    public static function boot()
+    protected static function boot()
     {
+        parent::boot();
+
         static::creating(function ($model) {
             $model->{$model->getKeyName()} = str_random(255);
         });


### PR DESCRIPTION
Since https://github.com/fico7489/laravel-pivot/pull/47 had some issues here is another attempt to add support for Laravel 5.7. Doesn't looked like there were any breaking chances, just had to call the `parent::boot` method in the Seller model.