### PR TITLE
Do not add custom events twice

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "illuminate/database": "^5.5|^6.0|^7.0|^8.0"
+        "illuminate/database": "^5.5|^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "*",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "illuminate/database": "^5.5|^6.0|^7.0|^8.0|^9.0"
+        "illuminate/database": "5.5.*|6.*|7.*|8.*|9.*"
     },
     "require-dev": {
         "orchestra/testbench": "*",

--- a/src/Traits/PivotEventTrait.php
+++ b/src/Traits/PivotEventTrait.php
@@ -20,8 +20,7 @@ trait PivotEventTrait
                 'pivotAttaching', 'pivotAttached',
                 'pivotDetaching', 'pivotDetached',
                 'pivotUpdating', 'pivotUpdated',
-            ],
-            $this->observables
+            ]
         );
     }
 


### PR DESCRIPTION
The parent::getObservableEvents() method already merge custom events ($this->observables) with eloquent events.