### PR TITLE
Added Laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "illuminate/database": "^5.5|^6.0|^7.0|^8.0"
+        "illuminate/database": "^5.5|^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "*",


### PR DESCRIPTION
Adds (explicit) support for Laravel 9.

**NOTE:** v3.0.3 _implicitly_ (incorrectly?) supports Laravel 9 and appears to be working. I noticed this when upgrading to Laravel 9 and my `fico7489/laravel-pivot` package was _downgraded_ to v3.0.3. This is because that version defined an `lluminate/database` requirement of `>5.5.0  || 6.*` which allows `lluminate/database` v9.X.

```
$ composer show laravel/framework
name     : laravel/framework
descrip. : The Laravel Framework.
keywords : framework, laravel
versions : * v9.2.0
[TRUNCATED]

$ composer show --tree fico7489/laravel-pivot
fico7489/laravel-pivot 3.0.3 This package introduces new eloquent events for sync(), attach(), detach() or updateExistingPivot() methods on BelongsToMany relation.
└──illuminate/database >5.5.0  || 6.*
```