### PR TITLE
update PHPUnit config (9.3)

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
@@ -10,8 +10,16 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         bootstrap="vendor/autoload.php"
->
+         bootstrap="vendor/autoload.php">
+     <coverage>
+       <include>
+          <directory>./src</directory>
+        </include>
+        <exclude>
+          <directory>./tests</directory>
+          <directory>./vendor</directory>
+        </exclude>
+      </coverage>
     <php>
         <ini name="error_reporting" value="-1"/>
     </php>
@@ -21,14 +29,4 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src</directory>
-            <exclude>
-                <directory>./tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
 </phpunit>


### PR DESCRIPTION
While looking into Laravel 10 support, I saw that CI tests were failing due to a deprecated PHPUnit config.
The PR contains the changes that the upgrade tool made. (`vendor/bin/phpunit --migrate-configuration`)

I've done a similar thing for [Laravel CTE](https://github.com/staudenmeir/laravel-cte/pull/44)