### PR TITLE
Remove override of the Framework's fireModelEvent method

### DIFF
--- a/src/Traits/ExtendFirePivotEventTrait.php
+++ b/src/Traits/ExtendFirePivotEventTrait.php
@@ -2,7 +2,7 @@
 
 namespace Fico7489\Laravel\Pivot\Traits;
 
-trait ExtendFireModelEventTrait
+trait ExtendFirePivotEventTrait
 {
     /**
      * Fire the given event for the model.
@@ -12,7 +12,7 @@ trait ExtendFireModelEventTrait
      *
      * @return mixed
      */
-    public function fireModelEvent($event, $halt = true, $relationName = null, $ids = [], $idsAttributes = [])
+    public function firePivotEvent($event, $halt = true, $relationName = null, $ids = [], $idsAttributes = [])
     {
         if (!isset(static::$dispatcher)) {
             return true;

--- a/src/Traits/FiresPivotEventsTrait.php
+++ b/src/Traits/FiresPivotEventsTrait.php
@@ -17,12 +17,12 @@ trait FiresPivotEventsTrait
     {
         list($idsOnly, $idsAttributes) = $this->getIdsWithAttributes($ids, $attributes);
 
-        if (false === $this->parent->fireModelEvent('pivotAttaching', true, $this->getRelationName(), $idsOnly, $idsAttributes)) {
+        if (false === $this->parent->firePivotEvent('pivotAttaching', true, $this->getRelationName(), $idsOnly, $idsAttributes)) {
             return false;
         }
 
         $parentResult = parent::attach($ids, $attributes, $touch);
-        $this->parent->fireModelEvent('pivotAttached', false, $this->getRelationName(), $idsOnly, $idsAttributes);
+        $this->parent->firePivotEvent('pivotAttached', false, $this->getRelationName(), $idsOnly, $idsAttributes);
 
         return $parentResult;
     }
@@ -43,12 +43,12 @@ trait FiresPivotEventsTrait
 
         list($idsOnly) = $this->getIdsWithAttributes($ids);
 
-        if (false === $this->parent->fireModelEvent('pivotDetaching', true, $this->getRelationName(), $idsOnly)) {
+        if (false === $this->parent->firePivotEvent('pivotDetaching', true, $this->getRelationName(), $idsOnly)) {
             return false;
         }
 
         $parentResult = parent::detach($ids, $touch);
-        $this->parent->fireModelEvent('pivotDetached', false, $this->getRelationName(), $idsOnly);
+        $this->parent->firePivotEvent('pivotDetached', false, $this->getRelationName(), $idsOnly);
 
         return $parentResult;
     }
@@ -65,12 +65,12 @@ trait FiresPivotEventsTrait
     {
         list($idsOnly, $idsAttributes) = $this->getIdsWithAttributes($id, $attributes);
 
-        if (false === $this->parent->fireModelEvent('pivotUpdating', true, $this->getRelationName(), $idsOnly, $idsAttributes)) {
+        if (false === $this->parent->firePivotEvent('pivotUpdating', true, $this->getRelationName(), $idsOnly, $idsAttributes)) {
             return false;
         }
 
         $parentResult = parent::updateExistingPivot($id, $attributes, $touch);
-        $this->parent->fireModelEvent('pivotUpdated', false, $this->getRelationName(), $idsOnly, $idsAttributes);
+        $this->parent->firePivotEvent('pivotUpdated', false, $this->getRelationName(), $idsOnly, $idsAttributes);
 
         return $parentResult;
     }

--- a/src/Traits/PivotEventTrait.php
+++ b/src/Traits/PivotEventTrait.php
@@ -5,7 +5,7 @@ namespace Fico7489\Laravel\Pivot\Traits;
 trait PivotEventTrait
 {
     use ExtendRelationsTrait;
-    use ExtendFireModelEventTrait;
+    use ExtendFirePivotEventTrait;
 
     /**
      * Get the observable event names.

--- a/tests/PivotEventTraitTest.php
+++ b/tests/PivotEventTraitTest.php
@@ -537,7 +537,8 @@ class PivotEventTraitTest extends TestCase
         $user->update(['name' => 'new_name']);
 
         $eventName = 'eloquent.updating: '.User::class;
-        $this->check_variables(0, [], [], null);
+
+        $this->assertCount(2, self::$events[0]);
     }
 
     private function check_events($events)


### PR DESCRIPTION
This change is motivated by 2 factors:

1. Reduce the likelihood of breaking changes being introduced by the framework
2. Allow other packages and applications to rely on the standard interface of the fireModelEvent method

This pull request does not change any functionality or behavior of the package. The only breaking change I could foresee is if a consuming application has started firing other model events with the custom `fireModelEvent` payload arguments. In that case, they should update their invocations of `fireModelEvent` to `firePivotEvent`.